### PR TITLE
Implemented logic to import Prism plugins

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -10,7 +10,14 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
   This Brocfile does *not* influence how the addon or the app using it
   behave. You most likely want to be modifying `./index.js` or app's Brocfile
 */
+var app = new EmberAddon({
 
-var app = new EmberAddon();
+  'ember-prism': {
+    plugins: [
+      'line-numbers',
+    ],
+  }
+
+});
 
 module.exports = app.toTree();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /* jshint node: true */
 'use strict';
 
+var fs = require('fs');
+
 module.exports = {
   name: 'ember-prism',
   included: function(app) {
@@ -24,6 +26,33 @@ module.exports = {
     if (options.components){
       options.components.forEach(function(component){
         app.import(app.bowerDirectory + '/prism/components/prism-' + component + '.js');
+      });
+    }
+
+    // import plugins
+    if (options.plugins){
+      options.plugins.forEach(function(plugin){
+
+        /**
+         * Most Prism plugins contains both a js file and a css file, but there
+         * are exception. `highlight-keywords` for instance, does not have a
+         * css file.
+         *
+         * When the plugin is imported, the app should check for file existence
+         * before calling `app.import()`.
+         */
+
+        // file extensions to be tested for existence.
+        var fileExtensions = ['js', 'css'];
+
+        fileExtensions.forEach(function(fileExtension) {
+          var file = app.bowerDirectory + '/prism/plugins/' + plugin + '/prism-' + plugin + '.' + fileExtension;
+
+          if (fs.existsSync(file)) {
+            app.import(file);
+          }
+        });
+
       });
     }
   }

--- a/tests/acceptance/code-block-test.js
+++ b/tests/acceptance/code-block-test.js
@@ -1,0 +1,20 @@
+import Ember from "ember";
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+var App;
+
+module('Acceptance | CodeBlock', {
+  beforeEach: function() {
+    App = startApp();
+  },
+  afterEach: function() {
+    Ember.run(App, App.destroy);
+  }
+});
+
+test('has `line-numbers` plugin', function(assert) {
+  visit('/').then(function() {
+    assert.equal(find('pre.codeblock.line-numbers').length, 1, 'One `pre.codeblock.line-numbers` is added to the template');
+    assert.equal(find('pre.codeblock .line-numbers-rows').length, 1, '`line-numbers` plugin generates one `.line-numbers-rows`');
+  });
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -4,4 +4,9 @@
   Can you dig it?
 &lt;/div&gt;{{/code-block}}
 
+<h3>With `line-numbers` plugin:</h3>
+{{#code-block class="line-numbers"}}&lt;div&gt;
+  Can you dig it?
+&lt;/div&gt;{{/code-block}}
+
 {{outlet}}


### PR DESCRIPTION
This PR fixes #5 by implementing the logic to import Prism plugins, as described in the readme file. It also comes with a small acceptance test to make sure everything works as expected.