### PR TITLE
Added 'none' filter, to have the option of providing custom css

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,13 +9,14 @@ module.exports = {
     //default theme name is 'default'
     var options = app.options['ember-prism'] || { components: [] };
 
-    //import main stylesheet
-    app.import(app.bowerDirectory + '/prism/themes/prism.css');
-
     //import theme based on options
     if (options.theme){
-      app.import(app.bowerDirectory + '/prism/themes/prism-' + options.theme + '.css');
+      // allow ability to specify no css if we want to provide our own
+      if (options.theme !== 'none'){
+        app.import(app.bowerDirectory + '/prism/themes/prism-' + options.theme + '.css');
+      } 
     } else {
+      // fall back to default theme
       app.import(app.bowerDirectory + '/prism/themes/prism.css');
     }
 


### PR DESCRIPTION
I needed the ability to provide a custom theme for prism. I don't like the idea of bringing in both the default theme + a custom one to override it, so the ability to omit any bundled theme would be nice.

This PR removes the default prism.css inclusion, and adds an extra conditional to make sure the user hasn't specified 'none' as a theme option.

example config:

```
var app = new EmberApp({
  'ember-prism': {
    'theme': 'none',
    'components': ['markup', 'css', 'javascript'],
    'plugins': []
  }
});
```