### PR TITLE
use new attribute binding syntax

### DIFF
--- a/app/templates/components/code-block.hbs
+++ b/app/templates/components/code-block.hbs
@@ -1,1 +1,1 @@
-<code {{bind-attr class='languageClass'}}>{{yield}}</code>
+<code class={{languageClass}}>{{yield}}</code>


### PR DESCRIPTION
This was giving me some deprecation warnings in ember-paper.