### PR TITLE
Allow ember-prism to be used by other addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,42 @@ var app = new EmberApp({
 
 If you want to use the default theme, just remove the `theme` option completely.
 
+### Usage from another addon
+
+If you want to enclude ember-prism from another addon, you'll need to do two things.
+First, make sure your addon's default blueprint installs the Prism Bower package.
+
+```js
+// blueprints/<addon-name>/index.js
+var installPrismBowerPackage = require('ember-prism/blueprints/ember-prism').installPrismBowerPackage;
+
+module.exports = {
+  // ...
+
+  afterInstall: function(options) {
+    return installPrismBowerPackage(this).then(function() {
+      // ...any other logic your blueprint needs
+    });
+  }
+};
+```
+
+Second, import all the required CSS and JS for Prism into the app's dependency tree.
+
+```js
+// index.js
+var importPrismSources = require('ember-prism').importPrismSources;
+
+module.exports = {
+  // ...
+
+  included: function(app) {
+    importPrismSources(app, { /* options to ember-prism */ });
+    // ...
+  }
+};
+```
+
 ## Running Locally
 
 * Run `ember server`

--- a/blueprints/ember-prism/index.js
+++ b/blueprints/ember-prism/index.js
@@ -8,6 +8,18 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('prism');
-  }
+    return installPrismBowerPackage(this);
+  },
+
+  installPrismBowerPackage: installPrismBowerPackage
 };
+
+/**
+ * Installs the Prism Bower package using the given blueprint instance.
+ * This function is a public hook to allow other addons that wish to use
+ * ember-prism to ensure that they're using the correct version of
+ * the package.
+ */
+function installPrismBowerPackage(blueprint) {
+  return blueprint.addBowerPackageToProject('prism');
+}

--- a/index.js
+++ b/index.js
@@ -6,55 +6,70 @@ var fs = require('fs');
 module.exports = {
   name: 'ember-prism',
   included: function(app) {
-    //default theme name is 'default'
-    var options = app.options['ember-prism'] || { components: [] };
+    /*
+     * If included by an addon rather than the root app, there will be no import method,
+     * so it's that addon's responsibility to call importPrismSources instead.
+     */
+    if (!app.import) { return; }
 
-    //import theme based on options
-    if (options.theme){
-      // allow ability to specify no css if we want to provide our own
-      if (options.theme !== 'none'){
-        app.import(app.bowerDirectory + '/prism/themes/prism-' + options.theme + '.css');
-      } 
-    } else {
-      // fall back to default theme
-      app.import(app.bowerDirectory + '/prism/themes/prism.css');
-    }
+    importPrismSources(app, app.options['ember-prism']);
+  },
 
-    //import main javascript
-    app.import(app.bowerDirectory + '/prism/prism.js');
-
-    //import components
-    if (options.components){
-      options.components.forEach(function(component){
-        app.import(app.bowerDirectory + '/prism/components/prism-' + component + '.js');
-      });
-    }
-
-    // import plugins
-    if (options.plugins){
-      options.plugins.forEach(function(plugin){
-
-        /**
-         * Most Prism plugins contains both a js file and a css file, but there
-         * are exception. `highlight-keywords` for instance, does not have a
-         * css file.
-         *
-         * When the plugin is imported, the app should check for file existence
-         * before calling `app.import()`.
-         */
-
-        // file extensions to be tested for existence.
-        var fileExtensions = ['js', 'css'];
-
-        fileExtensions.forEach(function(fileExtension) {
-          var file = app.bowerDirectory + '/prism/plugins/' + plugin + '/prism-' + plugin + '.' + fileExtension;
-
-          if (fs.existsSync(file)) {
-            app.import(file);
-          }
-        });
-
-      });
-    }
-  }
+  importPrismSources: importPrismSources
 };
+
+/**
+ * Imports all necessary Prism source styling and JS into the including app. This function
+ * is a public hook for addons that wish to use ember-prism within their own components.
+ */
+function importPrismSources(app, givenOptions) {
+  var options = givenOptions || {};
+
+  //import theme based on options
+  if (options.theme){
+    // allow ability to specify no css if we want to provide our own
+    if (options.theme !== 'none'){
+      app.import(app.bowerDirectory + '/prism/themes/prism-' + options.theme + '.css');
+    }
+  } else {
+    // fall back to default theme
+    app.import(app.bowerDirectory + '/prism/themes/prism.css');
+  }
+
+  //import main javascript
+  app.import(app.bowerDirectory + '/prism/prism.js');
+
+  //import components
+  if (options.components){
+    options.components.forEach(function(component){
+      app.import(app.bowerDirectory + '/prism/components/prism-' + component + '.js');
+    });
+  }
+
+  // import plugins
+  if (options.plugins){
+    options.plugins.forEach(function(plugin){
+
+      /**
+       * Most Prism plugins contains both a js file and a css file, but there
+       * are exception. `highlight-keywords` for instance, does not have a
+       * css file.
+       *
+       * When the plugin is imported, the app should check for file existence
+       * before calling `app.import()`.
+       */
+
+      // file extensions to be tested for existence.
+      var fileExtensions = ['js', 'css'];
+
+      fileExtensions.forEach(function(fileExtension) {
+        var file = app.bowerDirectory + '/prism/plugins/' + plugin + '/prism-' + plugin + '.' + fileExtension;
+
+        if (fs.existsSync(file)) {
+          app.import(file);
+        }
+      });
+
+    });
+  }
+}


### PR DESCRIPTION
This change allows addons to make use of `ember-prism` in their own components (with a bit of elbow grease from the author). It contains small refactorings to expose two functions, `installPrismBowerPackage` and `importPrismSources`, to allow consuming addons to pull Prism into their host applications. This follows a similar form-factor to the solution used by [ember-tether](https://github.com/yapplabs/ember-tether#using-ember-tether-in-your-own-addon).

I pulled the definition of those two functions off of their owning objects to reinforce for the authors of any future changes that they're now "public", but can move them back inline if you'd prefer.

The change as a whole just amounted to some refactoring and documentation. Apps using `ember-prism` today should see no difference.

Note: one acceptance test (``Acceptance | CodeBlock: has `line-numbers` plugin``) is failing, but that also seems to be the case on master.