### PR TITLE
Update reference to ember-cli-build.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You may need to use `&lt;`, and `&gt;` html attributes to escape `<`, and `>` ch
 You can set which theme, components, and plugins you'd like to use from Prism.
 
 ```javascript
-//Brocfile.js
+//ember-cli-build.js
 var app = new EmberApp({
   'ember-prism': {
     'theme': 'twilight',


### PR DESCRIPTION
Hey, we are looking at integrating this into `travis-web` and my coworker and I noticed this outdated reference in the README. Thanks for your work on this, very useful!