### PR TITLE
Update ember-cli-htmlbars dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "0.7.9"
+    "ember-cli-htmlbars": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Fixes a deprecation when using `ember-prism`:

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
    at Function.Addon.lookup (/Users/rjackson/Source/javascript/travis-web/node_modules/ember-cli/lib/models/addon.js:1009:27)
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
    at Function.Addon.lookup (/Users/rjackson/Source/javascript/travis-web/node_modules/ember-cli/lib/models/addon.js:1009:27)
```

Fixes #17.