### PR TITLE
Added support for usage as nested addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
       files: prismFiles,
     });
 
-    return new MergeTrees([vendorTree, prismTree]);
+    return MergeTrees([vendorTree, prismTree]);
   },
 
   included(app, parentAddon) {
@@ -44,7 +44,7 @@ module.exports = {
     // Defaults that can be overriden by options
     this.components = [];
     this.plugins = [];
-    this.theme = `themes/prism.css`;
+    this.theme = 'themes/prism.css';
 
     if (target.options && target.options['ember-prism']) {
       const options = target.options['ember-prism'];

--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ module.exports = {
       files: prismFiles,
     });
 
-    return MergeTrees([vendorTree, prismTree]);
+    if (vendorTree) {
+      return MergeTrees([vendorTree, prismTree]);
+    } else {
+      return prismTree;
+    }
   },
 
   included(app, parentAddon) {

--- a/index.js
+++ b/index.js
@@ -2,28 +2,71 @@
 'use strict';
 
 var fs = require('fs');
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-prism',
-  included(app) {
+
+  treeForVendor(vendorTree) {
+    let prismFiles = ['prism.js', this.theme].concat(this.components, this.plugins);
+    var prismTree = new Funnel(path.dirname(require.resolve('prismjs/prism.js')), {
+      files: prismFiles,
+    });
+
+    return new MergeTrees([vendorTree, prismTree]);
+  },
+
+  included(app, parentAddon) {
+    // Quick fix for add-on nesting
+    // https://github.com/aexmachina/ember-cli-sass/blob/v5.3.0/index.js#L73-L75
+    // see: https://github.com/ember-cli/ember-cli/issues/3718
+    while (typeof app.import !== 'function' && (app.app || app.parent)) {
+      app = app.app || app.parent;
+    }
+
+    // if app.import and parentAddon are blank, we're probably being consumed by an in-repo-addon
+    // or engine, for which the "bust through" technique above does not work.
+    if (typeof app.import !== 'function' && !parentAddon) {
+      if (app.registry && app.registry.app) {
+        app = app.registry.app;
+      }
+    }
+
+    // Per the ember-cli documentation
+    // http://ember-cli.com/extending/#broccoli-build-options-for-in-repo-addons
+    var target = (parentAddon || app);
+
+    const modulesPath = this.project.nodeModulesPath;
+    const prismModulePath = `${modulesPath}/prismjs`;
+
     // Defaults that can be overriden by options
     this.components = [];
     this.plugins = [];
-    this.theme = 'themes/prism.css';
+    this.theme = `themes/prism.css`;
 
-    if (app.options && app.options['ember-prism']) {
-      const options = app.options['ember-prism'];
+    if (target.options && target.options['ember-prism']) {
+      const options = target.options['ember-prism'];
       const components = options.components;
       const plugins = options.plugins;
       const theme = options.theme;
 
       if (theme && theme !== 'none') {
-        this.theme = `themes/prism-${theme}.css`;
+        let themePath = `themes/prism-${theme}.css`;
+        let file = `${prismModulePath}/${themePath}`;
+        if (fs.existsSync(file)) {
+          this.theme = themePath;
+        }
       }
 
       if (components) {
         components.forEach((component) => {
-          this.components.push(`components/prism-${component}.js`);
+          let componentPath = `components/prism-${component}.js`;
+          let file = `${prismModulePath}/${componentPath}`;
+          if (fs.existsSync(file)) {
+            this.components.push(componentPath);
+          }
         });
       }
 
@@ -43,12 +86,11 @@ module.exports = {
           const fileExtensions = ['js', 'css'];
 
           fileExtensions.forEach((fileExtension) => {
-            const nodeAssetsPath = `plugins/${plugin}/prism-${plugin}.${fileExtension}`;
-            const file = `node_modules/prismjs/${nodeAssetsPath}`;
-
+            let pluginPath = `plugins/${plugin}/prism-${plugin}.${fileExtension}`;
+            let file = `${prismModulePath}/${pluginPath}`;
 
             if (fs.existsSync(file)) {
-              this.plugins.push(nodeAssetsPath);
+              this.plugins.push(pluginPath);
             }
           });
 
@@ -56,18 +98,10 @@ module.exports = {
       }
     }
 
+    target.import(`vendor/prism.js`);
+    target.import(`vendor/${this.theme}`);
+    this.components.forEach((component) => target.import(`vendor/${component}`));
+    this.plugins.forEach((plugin) => target.import(`vendor/${plugin}`));
     this._super.included.apply(this, arguments);
-  },
-  options: {
-    nodeAssets: {
-      prismjs() {
-        return {
-          import: [
-            'prism.js',
-            this.theme
-          ].concat(this.components, this.plugins)
-        };
-      }
-    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "broccoli-funnel": "^1.2.0",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-node-assets": "^0.2.2",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -5,8 +5,6 @@ import config from './config/environment';
 
 let App;
 
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,


### PR DESCRIPTION
I noticed this addon did not work as a nested after its upgrade to use pure NPM dependencies.  I thought I would contribute back a PR to upgrade it properly work as a nested addon without breaking any of the existing functionality.

I also removed `Ember.MODEL_FACTORY_INJECTIONS` to stop that deprecation warning from showing up.