### PR TITLE
Search for options on the actual host app

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,13 @@ var fs = require('fs');
 
 module.exports = {
   name: 'ember-prism',
-  included(app) {
+  included() {
     // Defaults that can be overriden by options
     this.components = [];
     this.plugins = [];
     this.theme = 'themes/prism.css';
+
+    let app = findHost(this);
 
     if (app.options && app.options['ember-prism']) {
       const options = app.options['ember-prism'];
@@ -71,3 +73,16 @@ module.exports = {
     }
   }
 };
+
+
+// Polyfill [Addon._findHost](https://ember-cli.com/api/classes/Addon.html#method__findHost) for older versions of ember-cli
+function findHost(addon) {
+  var current = addon;
+  var app;
+
+  do {
+    app = current.app || app;
+  } while (current.parent.parent && (current = current.parent));
+
+  return app;
+}


### PR DESCRIPTION
Without this change I got errors when trying to configure `ember-prisim`
for use from another addon.

Moving `ember-prisim` to `dependencies` (rather than `devDependencies`)
and passing configuration results in an error:

> The Broccoli Plugin: [BroccoliMergeTrees: TreeMerger (vendor & appJS)] failed with:
> Error: ENOENT: no such file or directory, open '/<projectPath>/tmp/source_map_concat-input_base_path-RB1wFPjT.tmp/vendor/prismjs/components/prism-scss.js'

Adding this line makes avoids the problem and allows me to make my addon
dependant on `ember-prisim`